### PR TITLE
Add reformatting for alphas and betas

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -142,9 +142,9 @@ def _assemble_pip_impl(ctx):
         elif '-alpha' in version:
             version = version.replace('-alpha', 'a')
         elif '-beta-' in version:
-            version = version.replace('-beta-', 'a')
+            version = version.replace('-beta-', 'b')
         elif '-beta' in version:
-            version = version.replace('-beta', 'a')
+            version = version.replace('-beta', 'b')
         elif '-rc-' in version:
             version = version.replace('-rc-', 'rc')
         elif '-rc' in version:

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -137,6 +137,16 @@ def _assemble_pip_impl(ctx):
         if len(version) == 40:
             # this is a commit SHA, most likely
             version = "0.0.0+{}".format(version)
+        elif '-alpha-' in version:
+            version = version.replace('-alpha-', 'a')
+        elif '-alpha' in version:
+            version = version.replace('-alpha', 'a')
+        elif '-beta-' in version:
+            version = version.replace('-beta-', 'a')
+        elif '-beta' in version:
+            version = version.replace('-beta', 'a')
+        elif '-rc-' in version:
+            version = version.replace('-rc-', 'rc')
         elif '-rc' in version:
             version = version.replace('-rc', 'rc')
 


### PR DESCRIPTION
## What is the goal of this PR?

We add `pip` packages version reformatting from our (TypeDB) version conventions to [the python conventions](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) for `alpha` and `beta` releases.

## What are the changes implemented in this PR?

In addition to already existing `-rc` -> `rc` reformatting, we add:
* `-rc-` -> `rc`
* `-alpha-` -> `a`
* `-alpha` -> `a`
* `-beta-` -> `b`
* `-beta` -> `b`
To support multiple variants for better reusability.