### PR TITLE
Improve Apple code signing

### DIFF
--- a/common/shell/Shell.kt
+++ b/common/shell/Shell.kt
@@ -38,8 +38,8 @@ class Shell(private val logger: Logger, private val verbose: Boolean = false, pr
         return verbose && (!sensitive || printSensitiveData)
     }
 
-    class Command(vararg args: Argument) {
-        val args = args.toList()
+    class Command(val args: List<Argument>) {
+        constructor(vararg args: Argument): this(args.toList())
 
         override fun toString(): String {
             return args.toString()

--- a/platform/jvm/JVMPlatformAssembler.kt
+++ b/platform/jvm/JVMPlatformAssembler.kt
@@ -230,8 +230,10 @@ object JVMPlatformAssembler {
                     null -> logger.debug { "Skipping notarizing step: Apple code signing is not enabled" }
                     else -> {
                         MacAppNotarizer(
-                            dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg")
-                        ).notarize(codeSigningOptions)
+                            dmgPath = Path.of(distDir.path, "${options.image.filename}-$version.dmg"),
+                            appleCodeSigning = codeSigningOptions,
+                            logging = options.logging,
+                        ).notarize()
                         appleCodeSigner!!.deleteKeychain()
                     }
                 }

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -11,29 +11,33 @@ import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.STAPLER
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.SUBMIT
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.TEAM_ID
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.TIMEOUT
+import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.VERBOSE
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.WAIT
 import com.typedb.bazel.distribution.platform.jvm.ShellArgs.Programs.XCRUN
 import java.nio.file.Path
 
-class MacAppNotarizer(private val dmgPath: Path) {
-    fun notarize(appleCodeSigning: Options.AppleCodeSigning) {
-        shell.execute(notarizeCommand(appleCodeSigning)).outputString()
+class MacAppNotarizer(
+    private val dmgPath: Path, appleCodeSigning: Options.AppleCodeSigning, private val logging: Options.Logging
+) {
+    fun notarize() {
+        shell.execute(notarizeCommand).outputString()
         markPackageAsApproved()
     }
 
-    private fun notarizeCommand(appleCodeSigning: Options.AppleCodeSigning): Shell.Command {
-        return Shell.Command(
-                Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL), Shell.Command.arg(SUBMIT),
-                Shell.Command.arg(APPLE_ID), Shell.Command.arg(appleCodeSigning.appleID),
-                Shell.Command.arg(PASSWORD), Shell.Command.arg(appleCodeSigning.appleIDPassword, printable = false),
-                Shell.Command.arg(TEAM_ID), Shell.Command.arg(appleCodeSigning.appleTeamID, printable = false),
-                Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
-                Shell.Command.arg(dmgPath.toString()),
+    private val notarizeCommand = Shell.Command(
+        listOfNotNull(
+            Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL), Shell.Command.arg(SUBMIT),
+            if (logging.verbose) Shell.Command.arg(VERBOSE) else null,
+            Shell.Command.arg(APPLE_ID), Shell.Command.arg(appleCodeSigning.appleID),
+            Shell.Command.arg(PASSWORD), Shell.Command.arg(appleCodeSigning.appleIDPassword, printable = false),
+            Shell.Command.arg(TEAM_ID), Shell.Command.arg(appleCodeSigning.appleTeamID, printable = false),
+            Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
+            Shell.Command.arg(dmgPath.toString()),
         )
-    }
+    )
 
     private fun markPackageAsApproved() {
-        shell.execute(listOf(XCRUN, STAPLER, STAPLE, dmgPath.toString()))
+        shell.execute(listOfNotNull(XCRUN, STAPLER, STAPLE, if (logging.verbose) VERBOSE else null, dmgPath.toString()))
     }
 
     private object Args {
@@ -46,6 +50,7 @@ class MacAppNotarizer(private val dmgPath: Path) {
         const val SUBMIT = "submit"
         const val TIMEOUT = "--timeout"
         const val TEAM_ID = "--team-id"
+        const val VERBOSE = "-v"
         const val WAIT = "--wait"
     }
 }

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -1,5 +1,9 @@
 package com.typedb.bazel.distribution.platform.jvm
 
+import com.typedb.bazel.distribution.common.Logging.LogLevel
+import com.typedb.bazel.distribution.common.Logging.LogLevel.DEBUG
+import com.typedb.bazel.distribution.common.Logging.LogLevel.ERROR
+import com.typedb.bazel.distribution.common.Logging.Logger
 import com.typedb.bazel.distribution.common.shell.Shell
 import com.typedb.bazel.distribution.platform.jvm.JVMPlatformAssembler.shell
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.APPLE_ID
@@ -19,8 +23,11 @@ import java.nio.file.Path
 class MacAppNotarizer(
     private val dmgPath: Path, appleCodeSigning: Options.AppleCodeSigning, private val logging: Options.Logging
 ) {
+    private val logger = Logger(logLevel = if (logging.verbose) DEBUG else ERROR)
+
     fun notarize() {
         shell.execute(notarizeCommand).outputString()
+        logger.debug { "\nUse `xcrun notarytool log <submission-id>` to view further information about this notarization\n" }
         markPackageAsApproved()
     }
 

--- a/platform/jvm/MacAppNotarizer.kt
+++ b/platform/jvm/MacAppNotarizer.kt
@@ -5,6 +5,7 @@ import com.typedb.bazel.distribution.common.Logging.LogLevel.DEBUG
 import com.typedb.bazel.distribution.common.Logging.LogLevel.ERROR
 import com.typedb.bazel.distribution.common.Logging.Logger
 import com.typedb.bazel.distribution.common.shell.Shell
+import com.typedb.bazel.distribution.common.shell.Shell.Command.Companion.arg
 import com.typedb.bazel.distribution.platform.jvm.JVMPlatformAssembler.shell
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.APPLE_ID
 import com.typedb.bazel.distribution.platform.jvm.MacAppNotarizer.Args.NOTARYTOOL
@@ -31,17 +32,15 @@ class MacAppNotarizer(
         markPackageAsApproved()
     }
 
-    private val notarizeCommand = Shell.Command(
-        listOfNotNull(
-            Shell.Command.arg(XCRUN), Shell.Command.arg(NOTARYTOOL), Shell.Command.arg(SUBMIT),
-            if (logging.verbose) Shell.Command.arg(VERBOSE) else null,
-            Shell.Command.arg(APPLE_ID), Shell.Command.arg(appleCodeSigning.appleID),
-            Shell.Command.arg(PASSWORD), Shell.Command.arg(appleCodeSigning.appleIDPassword, printable = false),
-            Shell.Command.arg(TEAM_ID), Shell.Command.arg(appleCodeSigning.appleTeamID, printable = false),
-            Shell.Command.arg(WAIT), Shell.Command.arg(TIMEOUT), Shell.Command.arg(ONE_HOUR),
-            Shell.Command.arg(dmgPath.toString()),
-        )
-    )
+    private val notarizeCommand = Shell.Command(listOfNotNull(
+        arg(XCRUN), arg(NOTARYTOOL), arg(SUBMIT),
+        if (logging.verbose) arg(VERBOSE) else null,
+        arg(APPLE_ID), arg(appleCodeSigning.appleID),
+        arg(PASSWORD), arg(appleCodeSigning.appleIDPassword, printable = false),
+        arg(TEAM_ID), arg(appleCodeSigning.appleTeamID, printable = false),
+        arg(WAIT), arg(TIMEOUT), arg(ONE_HOUR),
+        arg(dmgPath.toString()),
+    ))
 
     private fun markPackageAsApproved() {
         shell.execute(listOfNotNull(XCRUN, STAPLER, STAPLE, if (logging.verbose) VERBOSE else null, dmgPath.toString()))


### PR DESCRIPTION
## Usage and product changes

- We remove the `skipIfSigned` functionality from the `AppleCodeSigner`
- We add verbose logging to `xcrun` calls if it is enabled

## Motivation

We've concluded that it is not the responsibility of a maintainer of an open-source library to sign their code for MacOS installers, as such we want to sign these packages ourselves. This may cause us to assume responsibility for issues in our application caused by these packages; this seems reasonable.

We have previously encountered issues when releasing `typedb-studio` due to a package that was signed, but not specifically for MacOS installers, failing Apple's checks. As such, we want to sign *all* packages captured by our `deepSignJarsRegex` - not just unsigned ones. This ensures that all signatures are valid.

However, we still value the `deepSignJarsRegex` to avoid unnecessarily unpackaging and re-signing every single jar we depend on.

## Implementation

We remove the `skipIfSigned` argument and the functionality gated behind it.

We also fix an issue where the `verbose` logging flag was not being correctly propagated to our code signing commands.